### PR TITLE
verbose mandatory with --silent flag for non log cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ var walletFile string
 var walletClientID string
 var walletClientKey string
 var cDir string
-var bStop bool
+var bSilent bool
 var allocUnderRepair bool
 
 var preferredBlobbers []string
@@ -52,7 +52,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&walletClientID, "wallet_client_id", "", "wallet client_id")
 	rootCmd.PersistentFlags().StringVar(&walletClientKey, "wallet_client_key", "", "wallet client_key")
 	rootCmd.PersistentFlags().StringVar(&cDir, "configDir", "", "configuration directory (default is $HOME/.zcn)")
-	rootCmd.PersistentFlags().BoolVar(&bStop, "s", false, "Doesnt prints sdk log in stderr")
+	rootCmd.PersistentFlags().BoolVar(&bSilent, "silent", false, "Do not show interactive sdk logs (shown by default)")
 
 }
 
@@ -120,15 +120,9 @@ func initConfig() {
 
 	//TODO: move the private key storage to the keychain or secure storage
 
-	//set the log file
-
-	if bStop {
-		zcncore.SetLogFile("cmdlog.log", !bStop)
-		sdk.SetLogFile("cmdlog.log", !bStop)
-	} else {
-		zcncore.SetLogFile("cmdlog.log", true)
-		sdk.SetLogFile("cmdlog.log", true)
-	}
+	// set the log file
+	zcncore.SetLogFile("cmdlog.log", !bSilent)
+	sdk.SetLogFile("cmdlog.log", !bSilent)
 
 	err := zcncore.InitZCNSDK(blockWorker, signScheme,
 		zcncore.WithChainID(chainID),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ var walletFile string
 var walletClientID string
 var walletClientKey string
 var cDir string
-var bVerbose bool
+var bStop bool
 var allocUnderRepair bool
 
 var preferredBlobbers []string
@@ -52,7 +52,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&walletClientID, "wallet_client_id", "", "wallet client_id")
 	rootCmd.PersistentFlags().StringVar(&walletClientKey, "wallet_client_key", "", "wallet client_key")
 	rootCmd.PersistentFlags().StringVar(&cDir, "configDir", "", "configuration directory (default is $HOME/.zcn)")
-	rootCmd.PersistentFlags().BoolVar(&bVerbose, "verbose", false, "prints sdk log in stderr (default false)")
+	rootCmd.PersistentFlags().BoolVar(&bStop, "s", false, "Doesnt prints sdk log in stderr")
+
 }
 
 func Execute() {
@@ -120,8 +121,14 @@ func initConfig() {
 	//TODO: move the private key storage to the keychain or secure storage
 
 	//set the log file
-	zcncore.SetLogFile("cmdlog.log", bVerbose)
-	sdk.SetLogFile("cmdlog.log", bVerbose)
+
+	if bStop {
+		zcncore.SetLogFile("cmdlog.log", !bStop)
+		sdk.SetLogFile("cmdlog.log", !bStop)
+	} else {
+		zcncore.SetLogFile("cmdlog.log", true)
+		sdk.SetLogFile("cmdlog.log", true)
+	}
 
 	err := zcncore.InitZCNSDK(blockWorker, signScheme,
 		zcncore.WithChainID(chainID),


### PR DESCRIPTION
Now we have mandatory --verbose and --s flag to not show sdk log in stderr.
Global flags look like :
`Flags:
      --config string              config file (default is config.yaml)
      --configDir string           configuration directory (default is $HOME/.zcn)
  -h, --help                       help for zbox
      --network string             network file to overwrite the network details (if required, default is network.yaml)
      --s                          Doesnt prints sdk log in stderr
      --wallet string              wallet file (default is wallet.json)
      --wallet_client_id string    wallet client_id
      --wallet_client_key string   wallet client_key

Use "zbox [command] --help" for more information about a command.`