### PR TITLE
Fixes the failing CI tests

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -1,5 +1,5 @@
 name: build-cli
-on: [push]
+on: [push, pull_request]
 jobs:
   build-linux:
     name: Build-linux

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/0chain/zboxcli
 go 1.13
 
 require (
-	github.com/0chain/gosdk v1.2.7-0.20210628150259-1051e746e876
+	github.com/0chain/gosdk v1.2.7-0.20210630153828-e2162c36dbfe
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/fatih/color v1.7.0 // indirect
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.4.0
 	golang.org/x/mobile v0.0.0-20200329125638-4c31acba0007 // indirect
 	golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/0chain/gosdk v1.2.7-0.20210628085042-5c0ae46ee967 h1:p3DlNtdGDNqVG5Le
 github.com/0chain/gosdk v1.2.7-0.20210628085042-5c0ae46ee967/go.mod h1:EntD+g2xA5SLUAm6JABMhkYAlTOmp0XhSnf/5xfwnV4=
 github.com/0chain/gosdk v1.2.7-0.20210628150259-1051e746e876 h1:1Za8trtP38tAks4CBKnNeodA14xyAEzi31o/ANIIdv8=
 github.com/0chain/gosdk v1.2.7-0.20210628150259-1051e746e876/go.mod h1:EntD+g2xA5SLUAm6JABMhkYAlTOmp0XhSnf/5xfwnV4=
+github.com/0chain/gosdk v1.2.7-0.20210630153828-e2162c36dbfe h1:CH2YTxIi6rS2A5HhE/g2wg4TLF/PHLkct/It4lmZ6OQ=
+github.com/0chain/gosdk v1.2.7-0.20210630153828-e2162c36dbfe/go.mod h1:EntD+g2xA5SLUAm6JABMhkYAlTOmp0XhSnf/5xfwnV4=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=


### PR DESCRIPTION
**_Issue_**:
CI tests were failing

#### _Why were CI tests failing ?_

These changes require a newer version of `gosdk`, so once `gosdk` got merged, we should update the `go.mod` and `go.sum` to use the newer version. 

**_How are we solving the failing test case ?_**

We are just updating to newer version of `gosdk`

**_Why was this not observed before pull_request got merged ?_**

CI tests are configured to run on push, so for pull_requests, they were not running! So all good for merge! no early indications of the issue 

**_How are we solving this issue for future ?_**

We are configuring the builds to run on every pull_request from now :) 



