### PR TITLE
Fix negative Wait Group counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,7 +1128,7 @@ Only the allocation's owner can successfully run `sync`.
 | allocation  | yes      | allocation id                                                                                 |         | string       |
 | commit      | no       | commet metadata to blockchain                                                                 | false   | boolean      |
 | encryptpath | no       | local directory path to be uploaded as encrypted                                              | false   | boolean      |
-| exludepath  | no       | paths to exclude from sync                                                                    |         | string array |
+| excludepath  | no       | paths to exclude from sync                                                                    |         | string array |
 | localchache | no       | local chache of remote snapshot. Used for comparsion with remote. After sync will be updated. |         | string       |
 | localpath   | yes      | local directory to which to sync                                                              |         | file path    |
 | uploadonly  | no       | only upload and update files                                                                  | false   | boolean      |

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -151,7 +151,7 @@ var syncCmd = &cobra.Command{
 				wg.Add(1)
 				err = allocationObj.DownloadFile(lPath, f.Path, statusBar)
 			case sdk.Upload:
-				//wg.Add(1)
+				wg.Add(1)
 				var attrs fileref.Attributes
 
 				encrypt := len(encryptpath) != 0 && strings.Contains(lPath, encryptpath)
@@ -164,7 +164,7 @@ var syncCmd = &cobra.Command{
 				// 	err = allocationObj.UploadFile(lPath, f.Path, attrs, statusBar)
 				// }
 			case sdk.Update:
-				//wg.Add(1)
+				wg.Add(1)
 
 				encrypt := len(encryptpath) != 0 && strings.Contains(lPath, encryptpath)
 


### PR DESCRIPTION
The zbox sync command is failing do to the error: `negative WaitGroup counter`

![image (1)](https://user-images.githubusercontent.com/19901130/143688797-95e8d635-61e2-45cb-9986-5ba8d4c25125.png)

This is to resolve the issue.