### PR TITLE
make blobberID field mandatory for sp-info command

### DIFF
--- a/cmd/stakepool.go
+++ b/cmd/stakepool.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/0chain/gosdk/zboxcore/sdk"
 	"github.com/0chain/gosdk/zcncore"
@@ -85,11 +86,12 @@ var spInfo = &cobra.Command{
 
 		doJSON, _ := cmd.Flags().GetBool("json")
 
-		if flags.Changed("blobber_id") {
-			if blobberID, err = flags.GetString("blobber_id"); err != nil {
-				log.Fatalf("can't get 'blobber_id' flag: %v", err)
-			}
+		if !flags.Changed("blobber_id") {
+			PrintError("Error: blobber_id flag is missing")
+			os.Exit(1)
 		}
+
+		blobberID = cmd.Flag("blobber_id").Value.String()
 
 		var info *sdk.StakePoolInfo
 		if info, err = sdk.GetStakePoolInfo(blobberID); err != nil {
@@ -267,7 +269,7 @@ func init() {
 	rootCmd.AddCommand(spUnlock)
 
 	spInfo.PersistentFlags().String("blobber_id", "",
-		"for given blobber, default is current client")
+		"for given blobber")
 	spInfo.PersistentFlags().Bool("json", false, "pass this option to print response as json data")
 
 	spUserInfo.PersistentFlags().Bool("json", false, "pass this option to print response as json data")

--- a/cmd/stakepool.go
+++ b/cmd/stakepool.go
@@ -91,7 +91,7 @@ var spInfo = &cobra.Command{
 			os.Exit(1)
 		}
 
-		blobberID = cmd.Flag("blobber_id").Value.String()
+			blobberID = flags.GetString("blobber_id")
 
 		var info *sdk.StakePoolInfo
 		if info, err = sdk.GetStakePoolInfo(blobberID); err != nil {

--- a/cmd/stakepool.go
+++ b/cmd/stakepool.go
@@ -87,7 +87,7 @@ var spInfo = &cobra.Command{
 		doJSON, _ := cmd.Flags().GetBool("json")
 
 		if !flags.Changed("blobber_id") {
-			PrintError("Error: blobber_id flag is missing")
+			log.Fatalf("Error: blobber_id flag is missing")
 			os.Exit(1)
 		}
 

--- a/cmd/stakepool.go
+++ b/cmd/stakepool.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/0chain/gosdk/zboxcore/sdk"
 	"github.com/0chain/gosdk/zcncore"
@@ -88,10 +87,12 @@ var spInfo = &cobra.Command{
 
 		if !flags.Changed("blobber_id") {
 			log.Fatalf("Error: blobber_id flag is missing")
-			os.Exit(1)
 		}
 
-			blobberID = flags.GetString("blobber_id")
+		blobberID, err = flags.GetString("blobber_id")
+		if err != nil {
+			log.Fatalf("Error: cannot get the value of blobber_id")
+		}
 
 		var info *sdk.StakePoolInfo
 		if info, err = sdk.GetStakePoolInfo(blobberID); err != nil {


### PR DESCRIPTION
A brief description of the changes in this PR:

blobber_id field is actually mandatory for sp-info. But if I dont provide any blobber, it takes client ID as default blobber_id. This is incorrect. Since blobber_id is necessary, we should take it from command line arguments. 


Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zboxcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- 0chain: 
- blobber:
- gosdk: https://github.com/0chain/gosdk/pull/602
- system_test:
- zwalletcli:
- Other: ...