### PR TITLE
make use of GetBlobbersOptions to query for active blobbers

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -106,21 +106,20 @@ var lsBlobers = &cobra.Command{
 		doJSON, _ := cmd.Flags().GetBool("json")
 		doAll, _ := cmd.Flags().GetBool("all")
 
-		var list, err = sdk.GetBlobbers()
-		var defaultList = filterActiveBlobbers(list)
+		options := sdk.GetBlobbersOptions{Active: true}
+		if doAll {
+			options.Active = false
+		}
 
+		var list, err = sdk.GetBlobbers(options)
 		if err != nil {
 			log.Fatalf("Failed to get storage SC configurations: %v", err)
 		}
 
-		if doAll {
-			defaultList = list
-		}
-
 		if doJSON {
-			util.PrintJSON(defaultList)
+			util.PrintJSON(list)
 		} else {
-			printBlobbers(defaultList)
+			printBlobbers(list)
 		}
 
 	},

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -106,12 +106,13 @@ var lsBlobers = &cobra.Command{
 		doJSON, _ := cmd.Flags().GetBool("json")
 		doAll, _ := cmd.Flags().GetBool("all")
 
-		options := sdk.GetBlobbersOptions{Active: true}
+		// set is_active=true to get only active blobbers
+		isActive := true
 		if doAll {
-			options.Active = false
+			isActive = false
 		}
 
-		var list, err = sdk.GetBlobbers(options)
+		var list, err = sdk.GetBlobbers(isActive)
 		if err != nil {
 			log.Fatalf("Failed to get storage SC configurations: %v", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/0chain/errors v1.0.3
-	github.com/0chain/gosdk v1.8.10-0.20221111114825-56d2e0184a4f
+	github.com/0chain/gosdk v1.8.10-0.20221114145446-abe470b98ed0
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/0chain/errors v1.0.3
-	github.com/0chain/gosdk v1.8.10-0.20221114050417-2eb86880a362
+	github.com/0chain/gosdk v1.8.10-0.20221111114825-56d2e0184a4f
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/0chain/errors v1.0.3
-	github.com/0chain/gosdk v1.8.10-0.20221114145446-abe470b98ed0
+	github.com/0chain/gosdk v1.8.10-0.20221115134857-bef9d4cabafd
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -38,12 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.10-0.20221109045505-4204e51685b3 h1:xjU2YR+Y/YYQYg4+afTvdReTLqbOGVrMv80WeLoC3GY=
-github.com/0chain/gosdk v1.8.10-0.20221109045505-4204e51685b3/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
-github.com/0chain/gosdk v1.8.10-0.20221114050417-2eb86880a362 h1:XOn+x0Uu/7N3C9TRYdYJXsrQRlCHahgG2fLPRKsehYg=
-github.com/0chain/gosdk v1.8.10-0.20221114050417-2eb86880a362/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
-github.com/0chain/gosdk v1.8.10-0.20221111114825-56d2e0184a4f h1:BKqoh7HRycPZxL6jvyiIa6NwnSRJiiNvKdr5dX3vsJk=
-github.com/0chain/gosdk v1.8.10-0.20221111114825-56d2e0184a4f/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
+github.com/0chain/gosdk v1.8.10-0.20221114145446-abe470b98ed0 h1:BIEhWl9UErudIhr4twdSn7grAk0R2KyM6f3asq6n75c=
+github.com/0chain/gosdk v1.8.10-0.20221114145446-abe470b98ed0/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/0chain/gosdk v1.8.10-0.20221109045505-4204e51685b3 h1:xjU2YR+Y/YYQYg4
 github.com/0chain/gosdk v1.8.10-0.20221109045505-4204e51685b3/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
 github.com/0chain/gosdk v1.8.10-0.20221114050417-2eb86880a362 h1:XOn+x0Uu/7N3C9TRYdYJXsrQRlCHahgG2fLPRKsehYg=
 github.com/0chain/gosdk v1.8.10-0.20221114050417-2eb86880a362/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
+github.com/0chain/gosdk v1.8.10-0.20221111114825-56d2e0184a4f h1:BKqoh7HRycPZxL6jvyiIa6NwnSRJiiNvKdr5dX3vsJk=
+github.com/0chain/gosdk v1.8.10-0.20221111114825-56d2e0184a4f/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.10-0.20221114145446-abe470b98ed0 h1:BIEhWl9UErudIhr4twdSn7grAk0R2KyM6f3asq6n75c=
-github.com/0chain/gosdk v1.8.10-0.20221114145446-abe470b98ed0/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
+github.com/0chain/gosdk v1.8.10-0.20221115134857-bef9d4cabafd h1:dSnxujVOFl8MsHlQFtt4VXIAIpXR0tyrL3AhEhWHT10=
+github.com/0chain/gosdk v1.8.10-0.20221115134857-bef9d4cabafd/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=


### PR DESCRIPTION
fixes: https://github.com/0chain/gosdk/issues/647

A brief description of the changes in this PR:

this PR introduced a new optional argument `GetBlobberOptions` to get active blobbers
https://github.com/0chain/gosdk/pull/644

Insteading of doing computation on local, we can ask the server directly for active blobbers

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zboxcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- 0chain: 
- blobber:
- gosdk: https://github.com/0chain/gosdk/pull/644
- system_test:
- zwalletcli:
- Other: ...