### PR TITLE
Upgrade 0Chain GoSDK to v1.8.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/0chain/errors v1.0.3
-	github.com/0chain/gosdk v1.8.10-0.20221116064523-169391a68f22
+	github.com/0chain/gosdk v1.8.10
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.10-0.20221116064523-169391a68f22 h1:jVRuBtcQmMCv3FmYYIeOljI7tjLLgKaJaZvwG6BWX0A=
-github.com/0chain/gosdk v1.8.10-0.20221116064523-169391a68f22/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
+github.com/0chain/gosdk v1.8.10 h1:bQHfSWwxdMmQ0OhCiqCI29/V/wdGxiTvWamOPn9r+Ic=
+github.com/0chain/gosdk v1.8.10/go.mod h1:sxM3NRQLwMWAzXKsKThR03lxHq03rtIMRODM/fdsZ3E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=


### PR DESCRIPTION
0Chain GoSDK `v1.8.10` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/v1.8.10