### PR TITLE
get active blobber directly from chain

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -87,15 +87,6 @@ func printBlobbers(nodes []*sdk.Blobber) {
 	}
 }
 
-func filterActiveBlobbers(blobbers []*sdk.Blobber) (activeBlobbers []*sdk.Blobber) {
-	for i := range blobbers {
-		if blobbers[i].LastHealthCheck.Within(60 * 60) {
-			activeBlobbers = append(activeBlobbers, blobbers[i])
-		}
-	}
-	return
-}
-
 // lsBlobers shows active blobbers
 var lsBlobers = &cobra.Command{
 	Use:   "ls-blobbers",
@@ -106,23 +97,21 @@ var lsBlobers = &cobra.Command{
 		doJSON, _ := cmd.Flags().GetBool("json")
 		doAll, _ := cmd.Flags().GetBool("all")
 
-		var list, err = sdk.GetBlobbers()
-		var defaultList = filterActiveBlobbers(list)
-
+		// set is_active=true to get only active blobbers
+		isActive := true
+		if doAll {
+			isActive = false
+		}
+		var list, err = sdk.GetBlobbers(isActive)
 		if err != nil {
 			log.Fatalf("Failed to get storage SC configurations: %v", err)
 		}
 
-		if doAll {
-			defaultList = list
-		}
-
 		if doJSON {
-			util.PrintJSON(defaultList)
+			util.PrintJSON(list)
 		} else {
-			printBlobbers(defaultList)
+			printBlobbers(list)
 		}
-
 	},
 }
 


### PR DESCRIPTION
A brief description of the changes in this PR:

On 0chain this PR adds a functionality to get active blobbers directly without having to filter from our side
https://github.com/0chain/0chain/pull/1754

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zboxcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- 0chain: 
- blobber:
- gosdk:
- system_test:
- zwalletcli:
- Other: ...