### PR TITLE
Consistent CLI command naming

### DIFF
--- a/cmd/addcurator.go
+++ b/cmd/addcurator.go
@@ -8,7 +8,8 @@ import (
 )
 
 var addCuratorCmd = &cobra.Command{
-	Use:   "addcurator",
+	Use:   "add-curator",
+	Aliases: []string{"addcurator"},
 	Short: "Adds a curator to an allocation",
 	Long:  "Adds a curator to an allocation",
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/challengepool.go
+++ b/cmd/challengepool.go
@@ -28,6 +28,7 @@ func printChallengePoolInfo(info *sdk.ChallengePoolInfo) {
 // cpInfo information
 var cpInfo = &cobra.Command{
 	Use:   "cp-info",
+	Aliases: []string {"challenge-pool"},
 	Short: "Challenge pool information.",
 	Long:  `Challenge pool information.`,
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/createdir.go
+++ b/cmd/createdir.go
@@ -9,7 +9,8 @@ import (
 )
 
 var createDirCmd = &cobra.Command{
-	Use:   "createdir",
+	Use:   "create-dir",
+	Aliases: []string {"createdir"},
 	Short: "Create directory",
 	Long:  `Create directory`,
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/fileRefs.go
+++ b/cmd/fileRefs.go
@@ -26,6 +26,7 @@ func checkError(err error) {
 
 var fileRefsCmd = &cobra.Command{
 	Use:   "recent-refs",
+	Aliases: []string{"file-refs"},
 	Short: "get list of recently added refs",
 	Long:  `get list of recently added refs`,
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/filemeta.go
+++ b/cmd/filemeta.go
@@ -13,6 +13,7 @@ import (
 // filemetaCmd represents file meta command
 var filemetaCmd = &cobra.Command{
 	Use:   "meta",
+	Aliases: []string{"file-meta"},
 	Short: "get meta data of files from blobbers",
 	Long:  `get meta data of files from blobbers`,
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/finalizeallocation.go
+++ b/cmd/finalizeallocation.go
@@ -29,6 +29,7 @@ func allocShouldNotBeFinalized(allocID string) {
 // finiAllocationCmd used to change allocation size and expiration
 var finiAllocationCmd = &cobra.Command{
 	Use:   "alloc-fini",
+	Aliases: []string{"fini-allocation"},
 	Short: "Finalize an expired allocation",
 	Long: `Finalize an expired allocation by allocation owner or one of
 blobbers of the allocation. It moves all tokens have to be moved between pools
@@ -65,6 +66,7 @@ and empties write pool moving left tokens to client.`,
 // doesn't provides their service in reality
 var cancelAllocationCmd = &cobra.Command{
 	Use:   "alloc-cancel",
+	Aliases: []string{"cancel-allocation"},
 	Short: "Cancel an allocation",
 	Long: `Cancel allocation used to terminate an allocation where, because
 of blobbers, it can't be used. Thus, the blobbers will not receive their

--- a/cmd/getallocation.go
+++ b/cmd/getallocation.go
@@ -37,6 +37,7 @@ func uploadCostFor1GB(alloc *sdk.Allocation) (cost common.Balance) {
 // getallocationCmd represents the get allocation info command
 var getallocationCmd = &cobra.Command{
 	Use:   "get",
+	Aliases: []string{"get-allocation"},
 	Short: "Gets the allocation info",
 	Long:  `Gets the allocation info`,
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/listallocations.go
+++ b/cmd/listallocations.go
@@ -13,7 +13,8 @@ import (
 )
 
 var listallocationsCmd = &cobra.Command{
-	Use:   "listallocations",
+	Use:   "list-allocations",
+	Aliases: []string{"listallocations"},
 	Short: "List allocations for the client",
 	Long:  `List allocations for the client`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/newallocation.go
+++ b/cmd/newallocation.go
@@ -47,7 +47,8 @@ func getPriceRange(val string) (pr sdk.PriceRange, err error) {
 
 // newallocationCmd represents the new allocation command
 var newallocationCmd = &cobra.Command{
-	Use:   "newallocation",
+	Use:   "new-allocation",
+	Aliases:[]string{"newallocation"},
 	Short: "Creates a new allocation",
 	Long:  `Creates a new allocation`,
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/removecurator.go
+++ b/cmd/removecurator.go
@@ -8,7 +8,8 @@ import (
 )
 
 var removeCuratorCmd = &cobra.Command{
-	Use:   "removecurator",
+	Use:   "remove-curator",
+	Aliases:[]string{"removecurator"},
 	Short: "Removes a curator from an allocation",
 	Long:  "Removes a curator from an allocation",
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/transferallocation.go
+++ b/cmd/transferallocation.go
@@ -8,7 +8,8 @@ import (
 )
 
 var transferAllocationCmd = &cobra.Command{
-	Use:   "transferallocation",
+	Use:   "transfer-allocation",
+	Aliases:[]string{"transferallocation"},
 	Short: "Transfer an allocation between owners",
 	Long:  "Transfer an allocation between owners, only a curator can transfer an allocation",
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/updateallocation.go
+++ b/cmd/updateallocation.go
@@ -11,7 +11,8 @@ import (
 
 // updateAllocationCmd used to change allocation size and expiration
 var updateAllocationCmd = &cobra.Command{
-	Use:   "updateallocation",
+	Use:   "update-allocation",
+	Aliases: []string{"updateallocation"},
 	Short: "Updates allocation's expiry and size",
 	Long:  `Updates allocation's expiry and size`,
 	Args:  cobra.MinimumNArgs(0),

--- a/cmd/walletinfo.go
+++ b/cmd/walletinfo.go
@@ -34,7 +34,8 @@ var walletDecryptCmd = &cobra.Command{
 
 // walletinfo used for getting the wallet info
 var walletinfoCmd = &cobra.Command{
-	Use:   "getwallet",
+	Use:   "get-wallet",
+	Aliases: []string {"getwallet"},
 	Short: "Get wallet information",
 	Long:  `Get wallet information`,
 	Args:  cobra.MinimumNArgs(0),


### PR DESCRIPTION
Closes #113 

A brief description of the changes in this PR:
- Use lower-hyphenated for commands
- Parameters naming needs discussion. Refer [here](https://stackoverflow.com/questions/64557741/how-to-support-an-old-flag-name-when-changing-to-a-new-flag-name-with-cobra) for alias in flags.

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zboxcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR
