### PR TITLE
Upgrade 0Chain GoSDK to v1.8.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/0chain/errors v1.0.3
-	github.com/0chain/gosdk v1.8.15-0.20230324074439-e95aedb29c87
+	github.com/0chain/gosdk v1.8.15
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/0chain/common v0.0.6-0.20221123040931-4a3feacdb97c h1:TDqF7VJa7uLLlEs
 github.com/0chain/common v0.0.6-0.20221123040931-4a3feacdb97c/go.mod h1:OxV9kVgVzAPgGHHPcS/aUSL2ZxNvKDU6jPoggKMbqns=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.15-0.20230324074439-e95aedb29c87 h1:bJpPhWlCv0a1nMKneWZT/GUurRLB4EPuWf2mRMEiPNc=
-github.com/0chain/gosdk v1.8.15-0.20230324074439-e95aedb29c87/go.mod h1:cBm7vTDxG+QvWb3SAnsYaOnLkBhUXc5UmtJn/QfVWKI=
+github.com/0chain/gosdk v1.8.15 h1:6VoFPZs2C/oI+Um0gdIPWWYpYXx0jm8grCsAbtRIJs8=
+github.com/0chain/gosdk v1.8.15/go.mod h1:cBm7vTDxG+QvWb3SAnsYaOnLkBhUXc5UmtJn/QfVWKI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Luzifer/go-openssl/v3 v3.1.0 h1:QqKqo6kYXGGUsvtUoCpRZm8lHw+jDfhbzr36gVj+/gw=


### PR DESCRIPTION
0Chain GoSDK `v1.8.15` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/v1.8.15