### PR TITLE
Fix misleading error message in collect-reward command

### DIFF
--- a/cmd/collect_reward.go
+++ b/cmd/collect_reward.go
@@ -26,7 +26,7 @@ var collectRewards = &cobra.Command{
 		}
 
 		if !flags.Changed("provider_type") {
-			log.Fatal("missing tokens flag")
+			log.Fatal("missing provider_type flag")
 		}
 
 		providerName, err := flags.GetString("provider_type")


### PR DESCRIPTION
The error message said 'missing tokens flag' but it should indicate that the required flag is 'provider_type'. This improves clarity when users forget to include the --provider_type flag.
